### PR TITLE
Add Kasten as an EKS-native Backup Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Amazon EKS runs up-to-date versions of the open-source Kubernetes software, so y
 * [Consul](https://learn.hashicorp.com/consul/kubernetes/aws-k8s)
 
 ## Backup
+* [Kasten K10](https://kasten.io)
 * [Velero](https://eksworkshop.com/intermediate/280_backup-and-restore/)
 
 ## Cost allocation


### PR DESCRIPTION
Also available on the AWS Container Marketplace but not sure if we want to indicate that somewhere - https://aws.amazon.com/marketplace/seller-profile?id=f6e5ffe6-8750-4be2-ad1f-31347397f9b8