### PR TITLE
adding kube-ps1 to list of CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Amazon EKS runs up-to-date versions of the open-source Kubernetes software, so y
 * [Krew](https://krew.sigs.k8s.io) - a plugin manager for kubectl
 * [kubectl-plugins](https://github.com/jordanwilson230/kubectl-plugins)
 * [kubectx](https://github.com/ahmetb/kubectx) — Faster way to switch between clusters and namespaces in kubectl 
+* [kube-ps1](https://github.com/jonmosco/kube-ps1) — Kubernetes prompt for bash and zsh.  Adds the current context and namespace to the prompt
 * [kui](https://github.com/IBM/kui/) - A hybrid command-line/UI development experience for cloud-native development
 * [kubectl debug](https://github.com/aylei/kubectl-debug) - Debug your pod by a new container with every troubleshooting tools pre-installed
 * [k9s](https://github.com/derailed/k9s) - Provides a terminal UI to interact with your Kubernetes clusters


### PR DESCRIPTION
Add `kube-ps1` to the list of CLI tools.  

A script that lets you add the current Kubernetes context and namespace configured on kubectl to your Bash/Zsh prompt strings (i.e. the $PS1).

Inspired by several tools used to simplify usage of kubectl.