### PR TITLE
feat: add KubeStellar Console to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Amazon EKS runs up-to-date versions of the open-source Kubernetes software, so y
 * [Using Prometheus Metrics in Amazon CloudWatch](https://aws.amazon.com/blogs/containers/using-prometheus-metrics-in-amazon-cloudwatch/)
 * [k8s-image-availability-exporter](https://github.com/flant/k8s-image-availability-exporter) - Alerts if an image used in Kubernetes cannot be pulled from container registry
 * [Mizu](https://github.com/up9inc/mizu) - The API Traffic Viewer for Kubernetes (Think TCPDump and Wireshark re-invented for Kubernetes)
+* [KubeStellar Console](https://github.com/kubestellar/console) — Multi-cluster Kubernetes dashboard with real-time observability, AI-powered operations, and CNCF project integrations across EKS and other clusters
 
 ## Troubleshooting
 * [kubespy](https://github.com/pulumi/kubespy)


### PR DESCRIPTION
## Description

Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **Monitoring** section.

KubeStellar Console is an AI-powered multi-cluster Kubernetes dashboard that works with any Kubernetes cluster including Amazon EKS. It provides:
- Real-time monitoring of workloads, cluster health, and resource bindings across multiple clusters
- 150+ built-in dashboard cards covering monitoring, networking, security, and more
- AI-assisted operations and natural language querying
- Multi-cluster visibility for EKS clusters managed via KubeStellar

Repository: https://github.com/kubestellar/console
License: Apache-2.0